### PR TITLE
feat(state): Wire page_size config through App to ListView

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -170,7 +170,7 @@ impl App {
     pub fn new() -> Self {
         debug!("Creating new application instance");
 
-        // Load configuration
+        // Load configuration (page_size is validated during load)
         let config = Config::load().unwrap_or_else(|e| {
             warn!("Failed to load config, using default: {}", e);
             Config::default()
@@ -180,7 +180,8 @@ impl App {
         let current_profile = config.get_default_profile().cloned();
         let profile_name = current_profile.as_ref().map(|p| p.name.clone());
 
-        let mut list_view = ListView::new();
+        // Create list view with configured page size
+        let mut list_view = ListView::with_page_size(config.settings.page_size);
         list_view.set_loading(true);
         list_view.set_profile_name(profile_name);
 
@@ -247,13 +248,17 @@ impl App {
     /// Create a new application instance with the given configuration.
     ///
     /// This is useful for testing and for custom initialization.
-    pub fn with_config(config: Config) -> Self {
+    pub fn with_config(mut config: Config) -> Self {
         debug!("Creating application with custom config");
+
+        // Validate page_size setting (in case config wasn't loaded via Config::load)
+        config.settings.validate_page_size();
 
         let current_profile = config.get_default_profile().cloned();
         let profile_name = current_profile.as_ref().map(|p| p.name.clone());
 
-        let mut list_view = ListView::new();
+        // Create list view with configured page size
+        let mut list_view = ListView::with_page_size(config.settings.page_size);
         list_view.set_loading(true);
         list_view.set_profile_name(profile_name);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -290,7 +290,8 @@ async fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Resul
 
                 // Also fetch fresh data in the background (if client available)
                 if let Some(ref c) = client {
-                    match c.search_issues(jql_query, 0, 50).await {
+                    let page_size = app.list_view().pagination().page_size;
+                    match c.search_issues(jql_query, 0, page_size).await {
                         Ok(result) => {
                             // Update cache
                             if let Some(ref cm) = cache_manager {
@@ -318,7 +319,8 @@ async fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Resul
                 }
             } else if let Some(ref c) = client {
                 // No cache, fetch from API
-                match c.search_issues(jql_query, 0, 50).await {
+                let page_size = app.list_view().pagination().page_size;
+                match c.search_issues(jql_query, 0, page_size).await {
                     Ok(result) => {
                         info!(
                             "Loaded {} issues from API (total: {})",

--- a/src/ui/views/list.rs
+++ b/src/ui/views/list.rs
@@ -299,8 +299,15 @@ pub struct ListView {
 }
 
 impl ListView {
-    /// Create a new list view.
+    /// Create a new list view with default page size.
     pub fn new() -> Self {
+        Self::with_page_size(PaginationState::DEFAULT_PAGE_SIZE)
+    }
+
+    /// Create a new list view with a custom page size.
+    ///
+    /// The page size controls how many issues are fetched per API request.
+    pub fn with_page_size(page_size: u32) -> Self {
         let mut table_state = TableState::default();
         table_state.select(Some(0));
         Self {
@@ -313,7 +320,7 @@ impl ListView {
             pending_g: false,
             filter_summary: None,
             sort: SortState::default(),
-            pagination: PaginationState::new(),
+            pagination: PaginationState::with_page_size(page_size),
             header_focused: false,
             focused_column: 0,
             search: QuickSearch::new(),
@@ -1580,6 +1587,21 @@ mod tests {
     fn test_pagination_state_with_page_size() {
         let state = PaginationState::with_page_size(25);
         assert_eq!(state.page_size, 25);
+    }
+
+    #[test]
+    fn test_list_view_with_page_size() {
+        let view = ListView::with_page_size(25);
+        assert_eq!(view.pagination().page_size, 25);
+    }
+
+    #[test]
+    fn test_list_view_new_uses_default_page_size() {
+        let view = ListView::new();
+        assert_eq!(
+            view.pagination().page_size,
+            PaginationState::DEFAULT_PAGE_SIZE
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements task #15: Wire page_size Config Through App to ListView

This PR connects the `page_size` configuration value from Settings through the App struct to initialize ListView's PaginationState with the user-configured page size instead of the hardcoded default of 50.

## Changes

- Added `ListView::with_page_size(page_size: u32)` constructor that creates a ListView with a custom page size
- Updated `ListView::new()` to delegate to `with_page_size()` using the default page size constant
- Updated `App::new()` to use `ListView::with_page_size()` with the configured `page_size` from settings
- Updated `App::with_config()` to validate page_size and use configured value
- Updated API calls in `main.rs` to use `app.list_view().pagination().page_size` instead of hardcoded `50`
- Added unit tests for `ListView::with_page_size()` and default page size behavior

## Testing

- [x] Unit tests added and passing (812 tests total)
- [x] `cargo clippy` passes with no errors
- [x] Manual testing: Changes to `page_size` in config take effect on app restart

## Checklist

- [x] Code follows project standards
- [x] All acceptance criteria from #15 met:
  - [x] App reads `page_size` from Settings during initialization
  - [x] ListView's PaginationState is initialized with the configured page_size
  - [x] API calls use the configured page_size as `max_results` parameter
  - [x] Changes to page_size in config take effect on app restart

Closes #15