### PR TITLE
feat(api): Add get_project_issue_types() method to JiraClient (#30)

### DIFF
--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -458,6 +458,39 @@ impl IssueSuggestion {
 }
 
 // ============================================================================
+// Issue Creation Metadata Types
+// ============================================================================
+
+/// Issue type metadata from the create metadata endpoint.
+///
+/// Used to populate issue type selection when creating issues.
+/// Returned by `GET /rest/api/3/issue/createmeta/{projectIdOrKey}/issuetypes`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct IssueTypeMeta {
+    /// The issue type ID.
+    pub id: String,
+    /// The issue type name (e.g., "Bug", "Story", "Task").
+    pub name: String,
+    /// The issue type description.
+    #[serde(default)]
+    pub description: String,
+    /// Whether this is a subtask type.
+    #[serde(default)]
+    pub subtask: bool,
+}
+
+/// Response from the issue type metadata endpoint.
+///
+/// Returned by `GET /rest/api/3/issue/createmeta/{projectIdOrKey}/issuetypes`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueTypeMetaResponse {
+    /// The available issue types for the project.
+    #[serde(default)]
+    pub issue_types: Vec<IssueTypeMeta>,
+}
+
+// ============================================================================
 // Issue Creation Types
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Implements task #30: Add `get_project_issue_types()` method to JiraClient

This PR adds the API method to fetch available issue types for a project from the JIRA create metadata endpoint. This enables populating issue type dropdowns when creating new issues, which is part of the "Create JIRA Issues from Issue List View" feature (#27).

## Changes

- Add `IssueTypeMeta` struct with `id`, `name`, `description`, and `subtask` fields to `src/api/types.rs`
- Add `IssueTypeMetaResponse` wrapper struct for the API response
- Add `get_project_issue_types()` method to `JiraClient` in `src/api/client.rs`
- Use `GET /rest/api/3/issue/createmeta/{projectIdOrKey}/issuetypes` endpoint
- Include proper error handling for invalid project (404) or permission errors (403)

## Testing

- [x] Code compiles without errors
- [x] All 821 existing tests pass
- [x] Clippy passes (only expected warning about new method being unused)
- [x] Method follows existing client patterns

## Checklist

- [x] Code follows project standards
- [x] Documentation updated (doc comments on new types and method)
- [x] All acceptance criteria met

Closes #30