### PR TITLE
feat(main-loop): Wire async operations for create issue form (#35)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1046,6 +1046,26 @@ async fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Resul
             }
         }
 
+        // Handle pending create issue request - spawn in background
+        if let Some(request) = app.take_pending_create_issue() {
+            if let Some(ref c) = client {
+                debug!("Creating issue in project: {}", request.fields.project.key);
+                task_spawner.spawn_create_issue(c, request);
+            } else {
+                app.handle_create_issue_failure("No JIRA connection");
+            }
+        }
+
+        // Handle pending fetch issue types request - spawn in background
+        if let Some(project_key) = app.take_pending_fetch_issue_types() {
+            if let Some(ref c) = client {
+                debug!("Fetching issue types for project: {}", project_key);
+                task_spawner.spawn_fetch_issue_types(c, project_key);
+            } else {
+                app.handle_fetch_issue_types_failure("No JIRA connection");
+            }
+        }
+
         // Check if we should quit
         if app.should_quit() {
             break;

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -132,11 +132,9 @@ pub enum ApiMessage {
     },
 
     /// Issue created
-    #[allow(dead_code)] // Will be used by CreateIssueView in future task
     IssueCreated(Result<CreateIssueResponse, String>),
 
     /// Issue types fetched for a project
-    #[allow(dead_code)] // Will be used by CreateIssueView in future task
     IssueTypesFetched(Result<Vec<IssueTypeMeta>, String>),
 }
 
@@ -599,7 +597,6 @@ impl TaskSpawner {
     }
 
     /// Spawn a task to create a new issue.
-    #[allow(dead_code)] // Will be used by CreateIssueView in future task
     pub fn spawn_create_issue(&self, client: &JiraClient, request: CreateIssueRequest) {
         let tx = self.tx.clone();
         let client = client.clone();
@@ -613,7 +610,6 @@ impl TaskSpawner {
     }
 
     /// Spawn a task to fetch issue types for a project.
-    #[allow(dead_code)] // Will be used by CreateIssueView in future task
     pub fn spawn_fetch_issue_types(&self, client: &JiraClient, project_key: String) {
         let tx = self.tx.clone();
         let client = client.clone();

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -14,7 +14,8 @@ pub use components::{
 };
 pub use theme::{init_theme, load_theme};
 pub use views::{
-    DeleteProfileDialog, DetailAction, DetailView, FilterPanelAction, FilterPanelView, FormField,
-    HelpAction, HelpView, ListAction, ListView, ProfileFormAction, ProfileFormData,
-    ProfileFormView, ProfileListAction, ProfileListView, ProfileSummary,
+    CreateIssueAction, CreateIssueRenderData, CreateIssueView, DeleteProfileDialog, DetailAction,
+    DetailView, FilterPanelAction, FilterPanelView, FormField, HelpAction, HelpView, ListAction,
+    ListView, ProfileFormAction, ProfileFormData, ProfileFormView, ProfileListAction,
+    ProfileListView, ProfileSummary,
 };

--- a/src/ui/views/mod.rs
+++ b/src/ui/views/mod.rs
@@ -11,9 +11,7 @@ mod history;
 mod list;
 mod profile;
 
-// CreateIssueView will be used by Task 4.2 (keybinding) and Task 5 (main loop integration)
-#[allow(unused_imports)]
-pub use create_issue::{CreateIssueAction, CreateIssueView};
+pub use create_issue::{CreateIssueAction, CreateIssueRenderData, CreateIssueView};
 pub use detail::{DetailAction, DetailView};
 pub use filter::{FilterPanelAction, FilterPanelView};
 pub use help::{HelpAction, HelpView};


### PR DESCRIPTION
## Summary
- Integrates the create issue form with the main event loop to handle async operations for issue creation and issue type fetching
- Adds pending flag checks in main.rs for spawning create issue and fetch issue types tasks
- Wires CreateIssueView to App with proper input handling and rendering
- Creates CreateIssueRenderData struct to resolve borrow checker issues when rendering
- Removes #[allow(dead_code)] from now-used TaskSpawner methods

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (834 tests)
- [x] `cargo clippy` passes
- [ ] Manual testing: Press 'n' from issue list to open create issue form
- [ ] Manual testing: Tab between fields navigates correctly
- [ ] Manual testing: Escape closes the form
- [ ] Manual testing: Selecting project triggers issue type fetch
- [ ] Manual testing: Submitting form triggers create issue request

Closes #35